### PR TITLE
- Pad batch dimension.

### DIFF
--- a/example_ctc_tpu.sh
+++ b/example_ctc_tpu.sh
@@ -6,7 +6,8 @@ bazel-bin/lingvo/trainer --logdir=$1 \
                          --mode=sync \
                          --model=asr.librispeech_ctc.Librispeech960Base \
                          --logtostderr \
-                         --tpu=grpc://10.240.1.2:8470
+                         --tpu=grpc://10.240.1.2:8470 \
+                         --job=executor_tpu
 
 # asr.librispeech_ctc.Librispeech960Base -> lingvo.tasks.asr.params.librispeech_ctc.Librispeech960Base
 # 10.240.1.2

--- a/lingvo/core/py_utils.py
+++ b/lingvo/core/py_utils.py
@@ -3689,6 +3689,17 @@ def PiecewiseConstant(x_in, boundaries, values, vdtype):
   return Matmul(tf.reshape(vs, (1, -1)), tf.transpose(one_hot_vec))[0][0]
 
 
+def PadBatchDimension(x, batch_size, pad_val):
+  rank = tf.rank(x)
+  with tf.control_dependencies([assert_greater_equal(rank, 1)]):
+    current_batch_size = tf.shape(x)[0]
+  with tf.control_dependencies([assert_less_equal(current_batch_size, batch_size)]):
+    fake_samples_in_batch = batch_size - current_batch_size
+    pad = tf.scatter_nd([[0, 1]], [fake_samples_in_batch], [rank, 2])
+  x = tf.pad(x, pad, constant_values=pad_val)
+  return x
+
+
 def PadSequenceDimension(x, length, pad_val, shape=None):
   """Pads x to `length` using `pad_val` along the second dim.
 

--- a/lingvo/tasks/asr/input_generator.py
+++ b/lingvo/tasks/asr/input_generator.py
@@ -129,6 +129,14 @@ class AsrInput(base_input_generator.BaseSequenceInputGenerator):
         src_paddings_shape = None
         tgt_shape = None
 
+      src_frames = py_utils.PadBatchDimension(src_frames, self.InfeedBatchSize(), 0)
+      src_paddings = py_utils.PadBatchDimension(src_paddings, self.InfeedBatchSize(),
+                                                1)
+      tgt_ids = py_utils.PadBatchDimension(tgt_ids, self.InfeedBatchSize(), 0)
+      tgt_labels = py_utils.PadBatchDimension(tgt_labels, self.InfeedBatchSize(), 0)
+      tgt_paddings = py_utils.PadBatchDimension(tgt_paddings, self.InfeedBatchSize(),
+                                                1)
+
       src_frames = py_utils.PadSequenceDimension(
           src_frames, p.source_max_length, 0, shape=src_frames_shape)
       src_paddings = py_utils.PadSequenceDimension(

--- a/lingvo/tasks/asr/params/librispeech_ctc.py
+++ b/lingvo/tasks/asr/params/librispeech_ctc.py
@@ -119,9 +119,9 @@ class Librispeech960Base(base_model_params.SingleTaskModelParams):
     # p.stacking_layer_tpl.right_context = 1
 
     tp = p.train
-    tp.learning_rate = 2.5e-4
+    tp.learning_rate = 1e-4
     tp.lr_schedule = schedule.ContinuousSchedule.Params().Set(
-        start_step=50000, half_life_steps=100000, min=0.01)
+        start_step=50_000, half_life_steps=100_000, min=0.01)
     tp.scale_gradients = False
     tp.l2_regularizer_weight = None
 
@@ -130,7 +130,7 @@ class Librispeech960Base(base_model_params.SingleTaskModelParams):
     # each of these sets is less than 5000), while train summaries will be
     # computed on 5000 examples.
     p.eval.samples_per_summary = 5000
-    p.eval.decoder_samples_per_summary = 0
+    p.eval.decoder_samples_per_summary = 5000
 
     return p
 


### PR DESCRIPTION
This prevents a crash on TPU from occuring when the final chunk of the dev
set doesn't fit into your batch.

This is very wonky. I am pretty sure (but not <90% certain) that now I
am doing a pass over the Dev set once every 50 training
steps. Essentially, in librispeech_ctc.py, eval_steps_per_loop is 5,
and the batch size is 96. The number of TPU's is 8. Multiplying those
together, you get: 3840, which is greater than 2703, the size of the
dev set. I'm not 100% sure that this is correct, though.

- Change the job type to "executor_tpu". This means that the eval and
train jobs will both run on the TPU. We probably want this long-term,
since CPU instances are not free for us, and we rarely evaluate the
dev set anyway.

- Change learning_rate to 1e-4 based on Anajali's experiments.

Currently running an experiment here:

gs://the-peoples-speech-west-europe/training_logs/galvez/tpu_ctc_2h